### PR TITLE
Drop pypy3 in CI for now

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,12 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', pypy3]
-        exclude: 
-          - os: macos-latest
-            python-version: pypy3
-          - os: windows-latest
-            python-version: pypy3
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Drop pypy3 in CI for now.

The C extensions side currently seems to fail to build.
