### PR TITLE
Fix incorrect build-requires in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "cython>=0.29", "wheel", "packaging"]
+requires = ["setuptools", "cython>=0.29", "packaging"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "cython>=0.29", "packaging"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- remove redundant `wheel` dependency (it is added automatically, see https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a)
- remove `cython` and `packaging` since neither of them is actually used