### PR TITLE
Move more metadata to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,7 @@ classifiers =
     Operating System :: POSIX
 project_urls =
     Repository = https://github.com/breezy-team/patiencediff
+
+[options]
+packages =
+    patiencediff

--- a/setup.py
+++ b/setup.py
@@ -2,32 +2,11 @@
 # encoding: utf-8
 
 from setuptools import setup, Extension
-from distutils import core
 
 ext_modules = [
     Extension(
         'patiencediff._patiencediff_c',
-        ['patiencediff/_patiencediff_c.c'])]
+        ['patiencediff/_patiencediff_c.c'], optional=True)]
 
 
-class Distribution(core.Distribution):
-
-    def is_pure(self):
-        if self.pure:
-            return True
-
-    def has_ext_modules(self):
-        return not self.pure
-
-    global_options = core.Distribution.global_options + [
-        ('pure', None, "use pure Python code instead of C "
-                       "extensions (slower on CPython)")]
-
-    pure = False
-
-
-setup(name="patiencediff",
-      packages=['patiencediff'],
-      test_suite='patiencediff.test_patiencediff',
-      distclass=Distribution,
-      ext_modules=ext_modules)
+setup(ext_modules=ext_modules)


### PR DESCRIPTION
Move more metadata to setup.cfg.

Use standard functionality for dealing with the fact the extension is optional.
