### PR TITLE
Fix spelling errors

### DIFF
--- a/patiencediff/_patiencediff_c.c
+++ b/patiencediff/_patiencediff_c.c
@@ -59,7 +59,7 @@ enum {
 };
 
 
-/* values from this array need to correspont to the order of the enum above */
+/* values from this array need to correspond to the order of the enum above */
 static char *opcode_names[] = {
     "equal",
     "insert",
@@ -585,7 +585,7 @@ load_lines(PyObject *orig, struct line **lines)
         line->data = item;
         line->hash = PyObject_Hash(item);
         if (line->hash == (-1)) {
-            /* Propogate the hash exception */
+            /* Propagate the hash exception */
             size = -1;
             goto cleanup;
         }


### PR DESCRIPTION
Fix spelling errors
Used config files:
    1: .codespellrc

-------8<-------
SUMMARY:
correspont    1
propogate     1
