### PR TITLE
Bumping python versions in GitHub workflows and pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,15 @@ license = {text = "GNU GPLv2 or later"}
 classifiers = [
     "Development Status :: 6 - Mature",
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.9",
     "Operating System :: POSIX",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumping python versions in GitHub workflows and pyproject.toml

* Updated the python-version in .github/workflows/disperse.yml
* Updated the python-version in .github/workflows/pythonpackage.yml
* Updated the python-version in .github/workflows/wheels.yaml
* Updated the requires-python field in pyproject.toml to ['3.13', '3.12', '3.11', '3.10', '3.9']
